### PR TITLE
Supports configuring the option to block public sharing of ebs snapshots

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [1.1.0](https://github.com/plus3it/terraform-aws-tardigrade-ec2-account/releases/tag/1.1.0)
+
+**Released**: 2024.09.20
+
+**Summary**:
+
+*   Supports configuring the option to block public sharing of ebs snapshots
+
 ### [1.0.0](https://github.com/plus3it/terraform-aws-tardigrade-ec2-account/releases/tag/1.0.0)
 
 **Released**: 2024.02.16

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Module to manage EC2 account settings
 <!-- BEGIN TFDOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.62.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.62.0 |
 
 ## Resources
 
@@ -21,7 +23,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ec2_account"></a> [ec2\_account](#input\_ec2\_account) | Object of inputs for ec2 account settings | <pre>object({<br>    ebs_encryption_by_default = optional(object({<br>      enabled         = optional(bool, true)<br>      default_kms_key = optional(string)<br>    }), {})<br>    image_block_public_access = optional(object({<br>      state = optional(string, "block-new-sharing")<br>    }), {})<br>    serial_console_access = optional(object({<br>      enabled = optional(bool, false)<br>    }))<br>  })</pre> | `{}` | no |
+| <a name="input_ec2_account"></a> [ec2\_account](#input\_ec2\_account) | Object of inputs for ec2 account settings | <pre>object({<br>    ebs_encryption_by_default = optional(object({<br>      enabled         = optional(bool, true)<br>      default_kms_key = optional(string)<br>    }), {})<br><br>    ebs_snapshot_block_public_access = optional(object({<br>      state = optional(string, "block-all-sharing")<br>    }), {})<br><br>    image_block_public_access = optional(object({<br>      state = optional(string, "block-new-sharing")<br>    }), {})<br><br>    serial_console_access = optional(object({<br>      enabled = optional(bool, false)<br>    }))<br>  })</pre> | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,10 @@ resource "aws_ebs_default_kms_key" "this" {
   key_arn = var.ec2_account.ebs_encryption_by_default.default_kms_key
 }
 
+resource "aws_ebs_snapshot_block_public_access" "this" {
+  state = var.ec2_account.ebs_snapshot_block_public_access.state
+}
+
 resource "aws_ec2_image_block_public_access" "this" {
   state = var.ec2_account.image_block_public_access.state
 }

--- a/tests/all-inputs/main.tf
+++ b/tests/all-inputs/main.tf
@@ -7,6 +7,10 @@ module "ec2_account" {
       default_kms_key = null
     }
 
+    ebs_snapshot_block_public_access = {
+      state = "block-new-sharing"
+    }
+
     image_block_public_access = {
       state = "block-new-sharing"
     }

--- a/variables.tf
+++ b/variables.tf
@@ -5,9 +5,15 @@ variable "ec2_account" {
       enabled         = optional(bool, true)
       default_kms_key = optional(string)
     }), {})
+
+    ebs_snapshot_block_public_access = optional(object({
+      state = optional(string, "block-all-sharing")
+    }), {})
+
     image_block_public_access = optional(object({
       state = optional(string, "block-new-sharing")
     }), {})
+
     serial_console_access = optional(object({
       enabled = optional(bool, false)
     }))

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.62.0"
+    }
+  }
+}


### PR DESCRIPTION
PR implementing in the aws provider: https://github.com/hashicorp/terraform-provider-aws/issues/34347